### PR TITLE
Fix address_purpose validation and restore status messages

### DIFF
--- a/R/npi_handle_requests.R
+++ b/R/npi_handle_requests.R
@@ -9,7 +9,7 @@ npi_get_results <- function(results = list(), ...) {
   msg <- glue::glue(
     "Requesting records {...$skip}-{...$skip + ...$limit}..."
   )
-  rlang::inform("status_pre_request", message = msg)
+  rlang::inform(msg, class = "status_pre_request")
 
   result <- npi_get(npi_url(), query = ...)
   append(results, list(result))

--- a/R/npi_search.R
+++ b/R/npi_search.R
@@ -141,12 +141,14 @@ npi_search <- function(number = NULL,
   }
 
   if (!is.null(address_purpose)) {
-    vals <- c("location", "mailing", "primary", "SECONDARY")
-    if (!address_purpose %in% vals) {
+    vals <- c("location", "mailing", "primary", "secondary")
+    address_purpose_lower <- tolower(address_purpose)
+    if (!address_purpose_lower %in% vals) {
       msg <- paste("`address_purpose` must be one of:",
                    stringr::str_c(vals, collapse = ", "))
       rlang::abort(msg)
     }
+    address_purpose <- vals[match(address_purpose_lower, vals)]
   }
 
   if (limit < 1L || limit > 1200) {
@@ -192,7 +194,7 @@ npi_process_results <- function(params) {
   user_n <- params[["limit"]]
 
   msg <- glue::glue("{user_n} record", ifelse(user_n > 1, "s", ""), " requested")
-  rlang::inform("status_pre_request", message = msg)
+  rlang::inform(msg, class = "status_pre_request")
 
   results <- npi_control_requests(params, user_n)
 


### PR DESCRIPTION
## Summary
- normalize `address_purpose` values to accept the documented lowercase "secondary"
- display pre-request status messages by passing the text as the primary `rlang::inform()` argument

## Testing
- Rscript -e 'devtools::test()' *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6908358c657c8321a8997910f49acb14