### PR TITLE
Add human-guided maintenance system

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,4 +14,7 @@
 ^pkgdown$
 ^\.github$
 ^cran-comments\.md$
+^AGENTS\.md$
+^MAINTENANCE\.md$
+^tools$
 ^CRAN-SUBMISSION$

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Report a reproducible problem with npi.
+title: "[Bug] "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: Please search existing issues first and remove sensitive provider data from examples.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the behavior you expected and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reprex
+    attributes:
+      label: Reproducible example
+      description: Provide the smallest code example that reproduces the problem.
+      render: r
+    validations:
+      required: true
+  - type: input
+    id: package-version
+    attributes:
+      label: npi version
+      placeholder: "0.3.1"
+    validations:
+      required: true
+  - type: input
+    id: r-version
+    attributes:
+      label: R version
+      placeholder: "4.5.1"
+    validations:
+      required: true
+  - type: textarea
+    id: session
+    attributes:
+      label: Session information
+      description: Paste the output of sessionInfo().
+      render: r
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: Feature request
+description: Suggest a focused improvement to npi.
+title: "[Feature] "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user problem or workflow would this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the smallest useful behavior and any compatibility implications.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What user-facing problem does this change address? Link the issue when applicable. -->
+
+## Root cause and behavior
+
+<!-- Describe the cause and the before/after behavior. Keep one root cause per pull request. -->
+
+## Validation
+
+- [ ] Focused tests for changed behavior
+- [ ] Full test suite
+- [ ] `R CMD check` (include result and any explained notes)
+- [ ] Documentation or NEWS updated when behavior changed
+- [ ] Live API access is not required for ordinary tests
+
+## Maintainer review
+
+<!-- List any compatibility, release, or design decision that needs Frank's approval. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/api-smoke.yaml
+++ b/.github/workflows/api-smoke.yaml
@@ -1,0 +1,39 @@
+name: API smoke test
+
+on:
+  schedule:
+    - cron: '47 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  api-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgload
+          needs: check
+
+      - name: Run API smoke test with bounded retries
+        run: |
+          for attempt in 1 2 3; do
+            if Rscript tools/api-smoke.R; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+          exit 1

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  schedule:
+    - cron: '17 13 * * 1'
+  workflow_dispatch:
 
 name: R-CMD-check
 
@@ -29,7 +32,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -51,7 +51,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -22,7 +22,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -53,6 +53,5 @@ jobs:
           git add CITATION.cff
           git commit -m 'Update CITATION.cff' || echo "No changes to commit"
           git push origin || echo "No changes to commit"
-
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .Rproj.user
 .Rhistory
 .RData
-.Rcheck
+*.Rcheck
 *.tar.gz
 CRAN-SUBMISSION
 cran-comments.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .Rproj.user
 .Rhistory
 .RData
+.Rcheck
+*.tar.gz
 CRAN-SUBMISSION
 cran-comments.md
 docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Maintenance instructions for npi
+
+These instructions apply to automated and agent-assisted maintenance of this repository.
+
+## Scope and review boundary
+
+- Work only on this `npi` repository.
+- Use one pull request per root cause. Do not combine unrelated bugs, dependency changes, or feature ideas.
+- Never merge code, publish a release, submit to CRAN, close an issue, or post a public issue or pull-request comment without explicit maintainer approval.
+- Search existing issues and pull requests before opening new work.
+
+## Package maintenance
+
+- Keep ordinary tests independent of the live NPI API. Use fixtures and mocks for deterministic tests.
+- Add a regression test before fixing a confirmed bug whenever practical.
+- Keep live API checks separate from package tests and assert only stable response structure.
+- Test R-devel, current R, and the previous R release. Older R versions may continue to work, but are not actively tested.
+- Do not raise `Depends: R` unless a reviewed change actually requires it.
+- Preserve the package's public behavior unless the issue or pull request explicitly justifies a change.
+
+## Required validation
+
+Run focused tests for changed behavior, then the full test suite and a full `R CMD check`.
+For release-facing work, run `R CMD check --as-cran` and record warnings and notes in `cran-comments.md`.
+Treat errors and new warnings as blocking. Explain unavoidable local-environment notes rather than changing package code for them.
+
+## Priorities
+
+Prioritize user-facing breakage, CRAN or CI failures, documentation defects, and feature ideas in that order.
+When a report lacks enough information, prepare a draft request for the maintainer instead of guessing publicly.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,33 @@
+# npi maintenance
+
+This repository uses a human-guided maintenance loop. Automated checks establish facts; Codex may investigate and prepare tested pull requests; Frank approves public decisions.
+
+## Operating policy
+
+- The weekly review runs after the scheduled package and API checks.
+- Routine action updates are grouped monthly and limited to one open dependency-update pull request.
+- Assistant-authored maintenance work is limited to two open pull requests at a time.
+- Pull requests are grouped by root cause and opened ready for review only after local validation passes.
+- Public replies are prepared as drafts for Frank. Automation does not merge, release, submit to CRAN, close issues, or publish comments.
+
+## Supported environments
+
+The active compatibility target is R-devel, the current R release, and the previous R release. Older R versions may continue to work but are not actively tested. The declared minimum R version is changed only when a reviewed package change requires it.
+
+## Weekly review
+
+The review inspects new and updated issues, open pull requests, CI results, the live NPI API smoke test, CRAN status, and recent releases. It searches for existing work before opening anything and stays quiet when there is no actionable change.
+
+Confirmed defects receive a regression test, the smallest safe fix, documentation updates when behavior changes, and a pull request containing the cause, impact, before/after behavior, and validation evidence. Incomplete reports receive a draft response. Feature requests receive an impact and compatibility assessment and wait for maintainer direction.
+
+## Release checklist
+
+When meaningful fixes accumulate, CRAN reports a problem, or an upstream API change requires an update:
+
+1. Choose patch or minor version according to public behavior changes.
+2. Update `DESCRIPTION`, `NEWS.md`, generated documentation, citation metadata, `codemeta.json`, and `cran-comments.md`.
+3. Run focused tests, the full test suite, `R CMD build`, and `R CMD check --as-cran`.
+4. Record GitHub matrix, reverse-dependency, and external platform results when available.
+5. Open a release pull request for maintainer review.
+
+CRAN submission, acceptance-email handling, tagging, GitHub release creation, and publication verification remain explicit human-approved steps. After acceptance, verify the canonical CRAN page, current-version checks, GitHub release, and rOpenSci documentation.

--- a/tools/api-smoke.R
+++ b/tools/api-smoke.R
@@ -1,0 +1,34 @@
+if (!requireNamespace("pkgload", quietly = TRUE)) {
+  stop("The pkgload package is required for the API smoke test.")
+}
+
+pkgload::load_all(".", quiet = TRUE)
+
+number <- Sys.getenv("NPI_SMOKE_NUMBER", unset = "1013259613")
+
+result <- tryCatch(
+  npi_search(number = number, limit = 1L),
+  error = function(error) {
+    stop("The NPI API smoke request failed: ", conditionMessage(error), call. = FALSE)
+  }
+)
+
+if (!inherits(result, "npi_results")) {
+  stop("The NPI API response did not produce an npi_results object.", call. = FALSE)
+}
+
+required <- c("npi", "enumeration_type", "created_date", "last_updated_date")
+if (!all(required %in% names(result))) {
+  stop("The NPI API response is missing required result columns.", call. = FALSE)
+}
+
+if (nrow(result) < 1L || anyNA(result$npi)) {
+  stop("The NPI API smoke lookup returned no usable NPI record.", call. = FALSE)
+}
+
+if (!inherits(result$created_date, "POSIXct") ||
+    !inherits(result$last_updated_date, "POSIXct")) {
+  stop("The NPI API response did not produce POSIXct timestamps.", call. = FALSE)
+}
+
+cat("NPI API smoke test passed: response shape and package parsing are healthy.\n")


### PR DESCRIPTION
## Summary

Adds a quiet, human-guided maintenance system for `npi`.

- Documents durable agent and maintainer rules.
- Adds structured bug and feature issue forms plus a pull request checklist.
- Schedules weekly package checks and a separate bounded live NPI API smoke test.
- Adds grouped monthly Dependabot updates for GitHub Actions.
- Updates checkout actions to v4.
- Keeps the live API separate from deterministic package tests.

No workflow merges code, publishes releases, submits to CRAN, closes issues, or posts public comments.

## Validation

- YAML files parsed successfully.
- Focused and full test suite passed after loading the package source.
- Live API smoke test passed.
- Controlled invalid-lookup smoke test failed as expected.
- `R CMD build .` passed.
- `R CMD check --as-cran npi_0.3.1.tar.gz` completed with 0 errors and 0 warnings; the 3 notes are existing local network, clock, and HTML-validator limitations.

After this setup PR is merged, the weekly Codex project automation can be created and run once for the initial backlog triage.